### PR TITLE
Fix failing KDL test

### DIFF
--- a/kinematics_interface/CMakeLists.txt
+++ b/kinematics_interface/CMakeLists.txt
@@ -17,8 +17,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 # Create interface library for kinematics base class
 add_library(kinematics_interface
     INTERFACE
-    include/kinematics_interface/kinematics_interface_base.hpp
-    )
+)
 
 target_include_directories(
     kinematics_interface

--- a/kinematics_interface/package.xml
+++ b/kinematics_interface/package.xml
@@ -14,8 +14,6 @@
 
   <depend>rclcpp_lifecycle</depend>
 
-  <test_depend>ament_cmake_gmock</test_depend>
-
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/kinematics_interface_kdl/CMakeLists.txt
+++ b/kinematics_interface_kdl/CMakeLists.txt
@@ -14,14 +14,14 @@ find_package(kinematics_interface REQUIRED)
 
 add_library(kinematics_interface_kdl SHARED
         src/kinematics_interface_kdl.cpp
-        )
+)
 
 ament_target_dependencies(kinematics_interface_kdl
         kdl_parser
         pluginlib
         Eigen3
         kinematics_interface
-        )
+)
 
 target_include_directories(
         kinematics_interface_kdl
@@ -46,7 +46,6 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
-  find_package(ros2_control_test_assets REQUIRED)
   find_package(ros2_control_test_assets REQUIRED)
 
   ament_add_gmock(

--- a/kinematics_interface_kdl/include/kinematics_interface_kdl/kinematics_interface_kdl.hpp
+++ b/kinematics_interface_kdl/include/kinematics_interface_kdl/kinematics_interface_kdl.hpp
@@ -37,8 +37,8 @@ namespace kinematics_interface_kdl
         /**
          * \brief KDL implementation of ros2_control kinematics interface
          */
-        virtual bool
-        initialize(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node, const std::string &end_effector_name);
+        bool
+        initialize(std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node, const std::string &end_effector_name) override;
 
       /**
        * \brief Convert Cartesian delta-x to joint delta-theta, using the Jacobian.
@@ -48,11 +48,11 @@ namespace kinematics_interface_kdl
        * \param[out] delta_theta_vec output vector with joint states
        * \return true if successful
        */
-      virtual bool
+      bool
       convert_cartesian_deltas_to_joint_deltas(const std::vector<double> &joint_pos,
                                                const std::vector<double> &delta_x_vec,
                                                const std::string &link_name,
-                                               std::vector<double> &delta_theta_vec);
+                                               std::vector<double> &delta_theta_vec) override;
 
       /**
        * \brief Convert joint delta-theta to Cartesian delta-x.
@@ -62,11 +62,11 @@ namespace kinematics_interface_kdl
        * \param[out] delta_x_vec  Cartesian deltas (x, y, z, wx, wy, wz)
        * \return true if successful
        */
-      virtual bool
+      bool
       convert_joint_deltas_to_cartesian_deltas(const std::vector<double> &joint_pos,
                                                const std::vector<double> &delta_theta_vec,
                                                const std::string &link_name,
-                                               std::vector<double> &delta_x_vec);
+                                               std::vector<double> &delta_x_vec) override;
 
       /**
       * \brief Calculates the joint transform for a specified link using provided joint positions.
@@ -75,9 +75,9 @@ namespace kinematics_interface_kdl
       * \param[out] transform_vec transformation matrix of the specified link in column major format.
       * \return true if successful
       */
-      virtual bool
+      bool
       calculate_link_transform(const std::vector<double> &joint_pos, const std::string &link_name,
-                               std::vector<double> &transform_vec);
+                               std::vector<double> &transform_vec) override;
 
       /**
       * \brief Calculates the joint transform for a specified link using provided joint positions.
@@ -86,17 +86,23 @@ namespace kinematics_interface_kdl
       * \param[out] jacobian Jacobian matrix of the specified link in column major format.
       * \return true if successful
       */
-      virtual bool
+      bool
       calculate_jacobian(const std::vector<double> &joint_pos, const std::string &link_name,
-                         std::vector<double> &jacobian);
+                         std::vector<double> &jacobian) override;
 
 
     private:
         bool update_joint_array(const std::vector<double>& joint_pos);
+
+        //verification methods
+        bool verify_initialized();
         bool verify_link_name(const std::string& link_name);
+        bool verify_transform_vector(const std::vector<double> &transform);
+        bool verify_cartesian_vector(const std::vector<double> &cartesian_vector);
+        bool verify_joint_vector(const std::vector<double> &joint_vector);
+        bool verify_jacobian(const std::vector<double> &jacobian_vector);
 
         bool initialized = false;
-        std::string end_effector_name_;
         std::string root_name_;
         size_t num_joints_;
         KDL::Chain chain_;

--- a/kinematics_interface_kdl/package.xml
+++ b/kinematics_interface_kdl/package.xml
@@ -4,15 +4,23 @@
   <name>kinematics_interface_kdl</name>
   <version>0.0.0</version>
   <description>KDL implementation of ros2_control kinematics interface</description>
-  <maintainer email="paul.gesel@picknik.ai">paul</maintainer>
+  <maintainer email="denis@stogl.de">Denis Štogl</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="paul.gesel@picknik.ai">Paul Gesel</maintainer>
   <license>Apache License 2.0</license>
+  <author email="paul.gesel@picknik.ai">Paul Gesel</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <build_depend>eigen</build_depend>
 
   <depend>kinematics_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>kdl_parser</depend>
 
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ros2_control_test_assets</test_depend>
+  <test_depend>ament_cmake_gmock</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
@@ -73,7 +73,7 @@ TEST_F(TestKDLPlugin, KDL_plugin_function) {
     ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector_, end_effector_transform));
 
     // convert cartesian delta to joint delta
-    std::vector<double> delta_x = {0, 0, 1, 0, 0, 0};
+    std::vector<double> delta_x = {0, 0, .5, 0, 0, 0};
     std::vector<double> delta_theta(2);
     ASSERT_TRUE(
             ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector_, delta_theta));
@@ -82,6 +82,12 @@ TEST_F(TestKDLPlugin, KDL_plugin_function) {
     std::vector<double> delta_x_est(6);
     ASSERT_TRUE(
             ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector_, delta_x_est));
+
+    // Ensure kinematics math is correct
+    for (auto i =0ul; i < delta_x.size(); i++){
+        ASSERT_NEAR(delta_x[i], delta_x_est[i], 0.01);
+    }
+
 }
 
 TEST_F(TestKDLPlugin, incorrect_input_sizes) {

--- a/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
@@ -25,7 +25,7 @@ public:
     std::shared_ptr<pluginlib::ClassLoader<kinematics_interface::KinematicsBaseClass>> ik_loader_;
     std::shared_ptr<kinematics_interface::KinematicsBaseClass> ik_;
     std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
-    std::string end_effector = "link2";
+    std::string end_effector_ = "link2";
 
     void SetUp() {
         // init ros
@@ -65,23 +65,23 @@ TEST_F(TestKDLPlugin, KDL_plugin_function) {
     loadAlphaParameter();
 
     // initialize the  plugin
-    ASSERT_TRUE(ik_->initialize(node_, end_effector));
+    ASSERT_TRUE(ik_->initialize(node_, end_effector_));
 
     // calculate end effector transform
     std::vector<double> pos = {0, 0};
     std::vector<double> end_effector_transform(16);
-    ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector, end_effector_transform));
+    ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector_, end_effector_transform));
 
     // convert cartesian delta to joint delta
     std::vector<double> delta_x = {0, 0, 1, 0, 0, 0};
     std::vector<double> delta_theta(2);
     ASSERT_TRUE(
-            ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector, delta_theta));
+            ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector_, delta_theta));
 
     // convert joint delta to cartesian delta
     std::vector<double> delta_x_est(6);
     ASSERT_TRUE(
-            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector, delta_x_est));
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector_, delta_x_est));
 }
 
 TEST_F(TestKDLPlugin, incorrect_input_sizes) {
@@ -90,7 +90,7 @@ TEST_F(TestKDLPlugin, incorrect_input_sizes) {
     loadAlphaParameter();
 
     // initialize the  plugin
-    ASSERT_TRUE(ik_->initialize(node_, end_effector));
+    ASSERT_TRUE(ik_->initialize(node_, end_effector_));
 
     // define correct values
     std::vector<double> pos = {0, 0};
@@ -103,32 +103,32 @@ TEST_F(TestKDLPlugin, incorrect_input_sizes) {
     std::vector<double> vec_5 = {1.0, 2.0, 3.0, 4.0, 5.0};
 
     // calculate transform
-    ASSERT_FALSE(ik_->calculate_link_transform(vec_5, end_effector, end_effector_transform));
+    ASSERT_FALSE(ik_->calculate_link_transform(vec_5, end_effector_, end_effector_transform));
     ASSERT_FALSE(ik_->calculate_link_transform(pos, "link_not_in_model", end_effector_transform));
-    ASSERT_FALSE(ik_->calculate_link_transform(pos, end_effector, vec_5));
+    ASSERT_FALSE(ik_->calculate_link_transform(pos, end_effector_, vec_5));
 
     // convert cartesian delta to joint delta
     ASSERT_FALSE(
-            ik_->convert_cartesian_deltas_to_joint_deltas(vec_5, delta_x, end_effector, delta_theta));
+            ik_->convert_cartesian_deltas_to_joint_deltas(vec_5, delta_x, end_effector_, delta_theta));
     ASSERT_FALSE(
-            ik_->convert_cartesian_deltas_to_joint_deltas(pos, vec_5, end_effector, delta_theta));
+            ik_->convert_cartesian_deltas_to_joint_deltas(pos, vec_5, end_effector_, delta_theta));
     ASSERT_FALSE(
             ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, "link_not_in_model", delta_theta));
-    ASSERT_FALSE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector, vec_5));
+    ASSERT_FALSE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector_, vec_5));
 
     // convert joint delta to cartesian delta
     ASSERT_FALSE(
-            ik_->convert_joint_deltas_to_cartesian_deltas(vec_5, delta_theta, end_effector, delta_x_est));
+            ik_->convert_joint_deltas_to_cartesian_deltas(vec_5, delta_theta, end_effector_, delta_x_est));
     ASSERT_FALSE(
-            ik_->convert_joint_deltas_to_cartesian_deltas(pos, vec_5, end_effector, delta_x_est));
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, vec_5, end_effector_, delta_x_est));
     ASSERT_FALSE(ik_->convert_joint_deltas_to_cartesian_deltas(
             pos, delta_theta, "link_not_in_model", delta_x_est));
     ASSERT_FALSE(
-            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector, vec_5));
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector_, vec_5));
 }
 
 TEST_F(TestKDLPlugin, KDL_plugin_no_robot_description) {
     // load alpha to parameter server
     loadAlphaParameter();
-    ASSERT_FALSE(ik_->initialize(node_, end_effector));
+    ASSERT_FALSE(ik_->initialize(node_, end_effector_));
 }

--- a/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
@@ -20,22 +20,21 @@
 #include "pluginlib/class_loader.hpp"
 #include "ros2_control_test_assets/descriptions.hpp"
 
-
 class TestKDLPlugin : public ::testing::Test {
 public:
     std::shared_ptr<pluginlib::ClassLoader<kinematics_interface::KinematicsBaseClass>> ik_loader_;
     std::shared_ptr<kinematics_interface::KinematicsBaseClass> ik_;
-    std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node;
+    std::shared_ptr<rclcpp_lifecycle::LifecycleNode> node_;
     std::string end_effector = "link2";
 
     void SetUp() {
         // init ros
         rclcpp::init(0, nullptr);
-        node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node");
-
+        node_ = std::make_shared<rclcpp_lifecycle::LifecycleNode>("test_node");
         std::string plugin_name = "kinematics_interface_kdl/KDLKinematics";
-        ik_loader_ = std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsBaseClass>>(
-                "kinematics_interface_kdl", "kinematics_interface::KinematicsBaseClass");
+        ik_loader_ =
+                std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsBaseClass>>(
+                        "kinematics_interface_kdl", "kinematics_interface::KinematicsBaseClass");
         ik_ = std::unique_ptr<kinematics_interface::KinematicsBaseClass>(
                 ik_loader_->createUnmanagedInstance(plugin_name));
     }
@@ -46,43 +45,90 @@ public:
     }
 
     void loadURDFParameter() {
-        auto urdf = std::string(ros2_control_test_assets::urdf_head) + std::string(ros2_control_test_assets::urdf_tail);
+        auto urdf = std::string(ros2_control_test_assets::urdf_head) +
+                    std::string(ros2_control_test_assets::urdf_tail);
         rclcpp::Parameter param("robot_description", urdf);
-        node->declare_parameter("robot_description", "");
-        node->set_parameter(param);
+        node_->declare_parameter("robot_description", "");
+        node_->set_parameter(param);
     }
 
     void loadAlphaParameter() {
         rclcpp::Parameter param("alpha", 0.005);
-        node->declare_parameter("alpha", 0.005);
-        node->set_parameter(param);
+        node_->declare_parameter("alpha", 0.005);
+        node_->set_parameter(param);
     }
 };
 
 TEST_F(TestKDLPlugin, KDL_plugin_function) {
-    std::vector<double> pos = {0, 0};
     // load robot description and alpha to parameter server
     loadURDFParameter();
     loadAlphaParameter();
 
-    ASSERT_TRUE(ik_->initialize(node, end_effector));
+    // initialize the  plugin
+    ASSERT_TRUE(ik_->initialize(node_, end_effector));
 
     // calculate end effector transform
-    std::vector<double> end_effector_transform(3 + 9);
+    std::vector<double> pos = {0, 0};
+    std::vector<double> end_effector_transform(16);
     ASSERT_TRUE(ik_->calculate_link_transform(pos, end_effector, end_effector_transform));
 
     // convert cartesian delta to joint delta
     std::vector<double> delta_x = {0, 0, 1, 0, 0, 0};
-    std::vector<double> delta_theta(6);
-    ASSERT_TRUE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector, delta_theta));
+    std::vector<double> delta_theta(2);
+    ASSERT_TRUE(
+            ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector, delta_theta));
 
     // convert joint delta to cartesian delta
     std::vector<double> delta_x_est(6);
-    ASSERT_TRUE(ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector, delta_x_est));
+    ASSERT_TRUE(
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector, delta_x_est));
+}
+
+TEST_F(TestKDLPlugin, incorrect_input_sizes) {
+    // load robot description and alpha to parameter server
+    loadURDFParameter();
+    loadAlphaParameter();
+
+    // initialize the  plugin
+    ASSERT_TRUE(ik_->initialize(node_, end_effector));
+
+    // define correct values
+    std::vector<double> pos = {0, 0};
+    std::vector<double> end_effector_transform(16);
+    std::vector<double> delta_x = {0, 0, 1, 0, 0, 0};
+    std::vector<double> delta_theta(2);
+    std::vector<double> delta_x_est(6);
+
+    // wrong size input vector
+    std::vector<double> vec_5 = {1.0, 2.0, 3.0, 4.0, 5.0};
+
+    // calculate transform
+    ASSERT_FALSE(ik_->calculate_link_transform(vec_5, end_effector, end_effector_transform));
+    ASSERT_FALSE(ik_->calculate_link_transform(pos, "link_not_in_model", end_effector_transform));
+    ASSERT_FALSE(ik_->calculate_link_transform(pos, end_effector, vec_5));
+
+    // convert cartesian delta to joint delta
+    ASSERT_FALSE(
+            ik_->convert_cartesian_deltas_to_joint_deltas(vec_5, delta_x, end_effector, delta_theta));
+    ASSERT_FALSE(
+            ik_->convert_cartesian_deltas_to_joint_deltas(pos, vec_5, end_effector, delta_theta));
+    ASSERT_FALSE(
+            ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, "link_not_in_model", delta_theta));
+    ASSERT_FALSE(ik_->convert_cartesian_deltas_to_joint_deltas(pos, delta_x, end_effector, vec_5));
+
+    // convert joint delta to cartesian delta
+    ASSERT_FALSE(
+            ik_->convert_joint_deltas_to_cartesian_deltas(vec_5, delta_theta, end_effector, delta_x_est));
+    ASSERT_FALSE(
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, vec_5, end_effector, delta_x_est));
+    ASSERT_FALSE(ik_->convert_joint_deltas_to_cartesian_deltas(
+            pos, delta_theta, "link_not_in_model", delta_x_est));
+    ASSERT_FALSE(
+            ik_->convert_joint_deltas_to_cartesian_deltas(pos, delta_theta, end_effector, vec_5));
 }
 
 TEST_F(TestKDLPlugin, KDL_plugin_no_robot_description) {
-
+    // load alpha to parameter server
     loadAlphaParameter();
-    ASSERT_FALSE(ik_->initialize(node, end_effector));
+    ASSERT_FALSE(ik_->initialize(node_, end_effector));
 }


### PR DESCRIPTION
The test was failing the transform vector  buffer was not the correct size. To fix this from happening again, I added verification to all inputs. 
https://github.com/ros-controls/kinematics_interface/issues/3