### PR TITLE
Add CI setup to the repository.

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,22 @@
+
+ROS2 Distro | Branch | Build status | Documentation | Released packages
+:---------: | :----: | :----------: | :-----------: | :---------------:
+**Rolling** | [`rolling`](https://github.com/ros-controls/kinematics_interface/tree/rolling) | [![Rolling Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-main.yml?branch=master) <br /> [![Rolling Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-testing.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-testing.yml?branch=master) <br /> [![Rolling Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-main.yml?branch=master) <br /> [![Rolling Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-testing.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-testing.yml?branch=master) <br /> [![Rolling Source Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-source-build.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-source-build.yml?branch=master) |   | [kinematics_interface](https://index.ros.org/p/kinematics_interface/#rolling)
+**Humble** | [`humble`](https://github.com/ros-controls/kinematics_interface/tree/humble) | [![Humble Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-main.yml?branch=master) <br /> [![Humble Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-testing.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-testing.yml?branch=master) <br /> [![Humble Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-main.yml?branch=master) <br /> [![Humble Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-testing.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-testing.yml?branch=master) <br /> [![Humble Source Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-source-build.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-source-build.yml?branch=master) |   | [kinematics_interface](https://index.ros.org/p/kinematics_interface/#humble)
+
+### Explanation of different build types
+
+**NOTE**: There are three build stages checking current and future compatibility of the package.
+
+[Detailed build status](.github/workflows/README.md)
+
+1. Binary builds - against released packages (main and testing) in ROS distributions. Shows that direct local build is possible.
+
+   Uses repos file: `$NAME$-not-released.<ros-distro>.repos`
+
+1. Semi-binary builds - against released core ROS packages (main and testing), but the immediate dependencies are pulled from source.
+   Shows that local build with dependencies is possible and if fails there we can expect that after the next package sync we will not be able to build.
+
+   Uses repos file: `$NAME$.repos`
+
+1. Source build - also core ROS packages are build from source. It shows potential issues in the mid future.

--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -1,0 +1,49 @@
+name: Coverage Build
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  coverage:
+    name: coverage build
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    env:
+      ROS_DISTRO: rolling
+    steps:
+      - uses: ros-tooling/setup-ros@0.3.4
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTRO }}
+      - uses: actions/checkout@v3
+      - uses: ros-tooling/action-ros-ci@0.2.6
+        with:
+          target-ros2-distro: ${{ env.ROS_DISTRO }}
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          # build all packages listed in the meta package
+          package-name:
+            kinematics_interface_kdl
+            kinematics_interface
+
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/kinematics_interface-not-released.${{ env.ROS_DISTRO }}.repos?token=${{ secrets.GITHUB_TOKEN }}
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: codecov/codecov-action@v3.1.0
+        with:
+          file: ros_ws/lcov/total_coverage.info
+          flags: unittests
+          name: codecov-umbrella
+      - uses: actions/upload-artifact@v3.1.0
+        with:
+          name: colcon-logs-coverage-rolling
+          path: ros_ws/log

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,0 +1,23 @@
+# This is a format job. Pre-commit has a first-party GitHub action, so we use
+# that: https://github.com/pre-commit/action
+
+name: Format
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  pre-commit:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9.7
+    - name: Install system hooks
+      run: sudo apt install -qq clang-format-12 cppcheck
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args: --all-files --hook-stage manual

--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -1,0 +1,41 @@
+name: ROS Lint
+on:
+  pull_request:
+
+jobs:
+  ament_lint:
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [cppcheck, copyright, lint_cmake]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/action-ros-lint@v0.1
+      with:
+        distribution: rolling
+        linter: ${{ matrix.linter }}
+        package-name:
+          kinematics_interface_kdl
+
+
+  ament_lint_100:
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [cpplint]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@v0.2
+    - uses: ros-tooling/action-ros-lint@v0.1
+      with:
+        distribution: rolling
+        linter: cpplint
+        arguments: "--linelength=100 --filter=-whitespace/newline"
+        package-name:
+          kinematics_interface_kdl
+          kinematics_interface

--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -1,0 +1,20 @@
+name: Humble - ABI Compatibility Check
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  abi_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: humble
+          ROS_REPO: main
+          ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}
+          NOT_TEST_BUILD: true

--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -24,5 +24,3 @@ jobs:
       ros_repo: main
       upstream_workspace: kinematics_interface-not-released.humble.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-binary-build-main.yml
+++ b/.github/workflows/humble-binary-build-main.yml
@@ -1,0 +1,28 @@
+name: Humble Binary Build - main
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: main
+      upstream_workspace: kinematics_interface-not-released.humble.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -1,0 +1,28 @@
+name: Humble Binary Build - testing
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      upstream_workspace: kinematics_interface-not-released.humble.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-binary-build-testing.yml
+++ b/.github/workflows/humble-binary-build-testing.yml
@@ -24,5 +24,3 @@ jobs:
       ros_repo: testing
       upstream_workspace: kinematics_interface-not-released.humble.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -1,0 +1,33 @@
+name: Humble RHEL Binary Build
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+
+jobs:
+  humble_rhel_binary:
+    name: Humble RHEL binary build
+    runs-on: ubuntu-latest
+    env:
+      ROS_DISTRO: humble
+    container: jaronl/ros:humble-alma
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src/kinematics_interface
+      - run: |
+          rosdep update
+          rosdep install -iy --from-path src/kinematics_interface
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          colcon build
+          colcon test

--- a/.github/workflows/humble-semi-binary-build-main.yml
+++ b/.github/workflows/humble-semi-binary-build-main.yml
@@ -1,0 +1,27 @@
+name: Humble Semi-Binary Build - main
+# description: 'Build & test that compiles the main dependencies from source.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  semi_binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: main
+      upstream_workspace: kinematics_interface.humble.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-semi-binary-build-main.yml
+++ b/.github/workflows/humble-semi-binary-build-main.yml
@@ -23,5 +23,3 @@ jobs:
       ros_repo: main
       upstream_workspace: kinematics_interface.humble.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-semi-binary-build-testing.yml
+++ b/.github/workflows/humble-semi-binary-build-testing.yml
@@ -1,0 +1,27 @@
+name: Humble Semi-Binary Build - testing
+# description: 'Build & test that compiles the main dependencies from source.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  semi_binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: humble
+      ros_repo: testing
+      upstream_workspace: kinematics_interface.humble.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-semi-binary-build-testing.yml
+++ b/.github/workflows/humble-semi-binary-build-testing.yml
@@ -23,5 +23,3 @@ jobs:
       ros_repo: testing
       upstream_workspace: kinematics_interface.humble.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -1,0 +1,19 @@
+name: Humble Source Build
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 3 * * *'
+
+jobs:
+  source:
+    uses: ./.github/workflows/reusable-ros-tooling-source-build.yml
+    with:
+      ros_distro: humble
+      ref: master
+      ros2_repo_branch: master-humble

--- a/.github/workflows/prerelease-check.yml
+++ b/.github/workflows/prerelease-check.yml
@@ -1,0 +1,39 @@
+name: Pre-Release Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      ros_distro:
+        description: 'Chose ROS distribution'
+        required: true
+        default: 'rolling'
+        type: choice
+        options:
+        - foxy
+        - galactic
+        - humble
+        - rolling
+      branch:
+        description: 'Chose branch for distro'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+        - foxy
+        - galactic
+        - humble
+        - master
+
+jobs:
+  pre_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: industrial_ci
+        uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: ${{ github.event.inputs.ros_distro }}
+          PRERELEASE: true
+          BASEDIR: ${{ github.workspace }}/.work

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -1,0 +1,96 @@
+name: Reusable industrial_ci Workflow with Cache
+# Reusable action to simplify dealing with ROS/ROS2 industrial_ci builds with cache
+# author: Denis Štogl <denis@stoglrobotics.de>
+
+on:
+  workflow_call:
+    inputs:
+      ref_for_scheduled_build:
+        description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
+        default: ''
+        required: false
+        type: string
+
+      upstream_workspace:
+        description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
+        required: true
+        type: string
+      ros_distro:
+        description: 'ROS_DISTRO variable for industrial_ci'
+        required: true
+        type: string
+      ros_repo:
+        description: 'ROS_REPO to run for industrial_ci. Possible values: "main", "testing"'
+        default: 'main'
+        required: false
+        type: string
+      os_code_name:
+        description: 'OS_CODE_NAME variable for industrial_ci'
+        default: ''
+        required: false
+        type: string
+      before_install_upstream_dependencies:
+        description: 'BEFORE_INSTALL_UPSTREAM_DEPENDENCIES variable for industrial_ci'
+        default: ''
+        required: false
+        type: string
+
+      ccache_dir:
+        description: 'Local path to store cache (from "github.workspace"). For standard industrial_ci configuration do not have to be changed'
+        default: '.ccache'
+        required: false
+        type: string
+      basedir:
+        description: 'Local path to workspace base directory to cache (from "github.workspace"). For standard industrial_ci configuration do not have to be changed'
+        default: '.work'
+        required: false
+        type: string
+
+
+jobs:
+  reusable_industrial_ci_with_cache:
+    name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }} ${{ inputs.os_code_name }}
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
+      BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}
+      CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.os_code_name }}-${{ inputs.ros_repo }}-${{ github.job }}
+    steps:
+      - name: Checkout ${{ inputs.ref }} when build is not scheduled
+        if: ${{ github.event_name != 'schedule' }}
+        uses: actions/checkout@v3
+      - name: Checkout ${{ inputs.ref }} on scheduled build
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref_for_scheduled_build }}
+      - name: cache target_ws
+        if: ${{ ! matrix.env.CCOV }}
+        uses: pat-s/always-upload-cache@v2.1.5
+        with:
+          path: ${{ env.BASEDIR }}/target_ws
+          key: target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}-${{ github.run_id }}
+          restore-keys: |
+            target_ws-${{ env.CACHE_PREFIX }}-${{ hashFiles('**/CMakeLists.txt', '**/package.xml') }}
+      - name: cache ccache
+        uses: pat-s/always-upload-cache@v2.1.5
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ccache-${{ env.CACHE_PREFIX }}
+      - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          ROS_DISTRO: ${{ inputs.ros_distro }}
+          ROS_REPO: ${{ inputs.ros_repo }}
+          OS_CODE_NAME: ${{ inputs.os_code_name }}
+          BEFORE_INSTALL_UPSTREAM_DEPENDENCIES: ${{ inputs.before_install_upstream_dependencies }}
+      - name: prepare target_ws for cache
+        if: ${{ always() && ! matrix.env.CCOV }}
+        run: |
+          du -sh ${{ env.BASEDIR }}/target_ws
+          sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete
+          sudo rm -rf ${{ env.BASEDIR }}/target_ws/src
+          du -sh ${{ env.BASEDIR }}/target_ws

--- a/.github/workflows/reusable-ros-tooling-source-build.yml
+++ b/.github/workflows/reusable-ros-tooling-source-build.yml
@@ -1,0 +1,50 @@
+name: Reusable industrial_ci Workflow with Cache
+# Reusable action to simplify dealing with ROS/ROS2 industrial_ci builds with cache
+# author: Denis Štogl <denis@stoglrobotics.de>
+
+on:
+  workflow_call:
+    inputs:
+      ros_distro:
+        description: 'ROS2 distribution name'
+        required: true
+        type: string
+      ref:
+        description: 'Reference on which the repo should be checkout. Usually is this name of a branch or a tag.'
+        required: true
+        type: string
+      ros2_repo_branch:
+        description: 'Branch in the ros2/ros2 repozitory from which ".repos" should be used. Possible values: master (Rolling), humble, galactic, foxy.'
+        default: 'master'
+        required: false
+        type: string
+
+jobs:
+  reusable_ros_tooling_source_build:
+    name: ${{ inputs.ros_distro }} ubuntu-22.04
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: ros-tooling/setup-ros@0.3.4
+        with:
+          required-ros-distributions: ${{ inputs.ros_distro }}
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ros-tooling/action-ros-ci@0.2.6
+        with:
+          target-ros2-distro: ${{ inputs.ros_distro }}
+          # build all packages listed in the meta package
+          package-name:
+            kinematics_interface_kdl
+            kinematics_interface
+
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/ros2/ros2/${{ inputs.ros2_repo_branch }}/ros2.repos
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/kinematics_interface.${{ inputs.ros_distro }}.repos?token=${{ secrets.GITHUB_TOKEN }}
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs-ubuntu-22.04
+          path: ros_ws/log

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -1,0 +1,20 @@
+name: Rolling - ABI Compatibility Check
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  abi_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ros-industrial/industrial_ci@master
+        env:
+          ROS_DISTRO: rolling
+          ROS_REPO: main
+          ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}
+          NOT_TEST_BUILD: true

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -24,5 +24,3 @@ jobs:
       ros_repo: main
       upstream_workspace: kinematics_interface-not-released.rolling.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -1,0 +1,28 @@
+name: Rolling Binary Build - main
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: main
+      upstream_workspace: kinematics_interface-not-released.rolling.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -1,0 +1,28 @@
+name: Rolling Binary Build - testing
+# author: Denis Štogl <denis@stoglrobotics.de>
+# description: 'Build & test all dependencies from released (binary) packages.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      upstream_workspace: kinematics_interface-not-released.rolling.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-binary-build-testing.yml
+++ b/.github/workflows/rolling-binary-build-testing.yml
@@ -24,5 +24,3 @@ jobs:
       ros_repo: testing
       upstream_workspace: kinematics_interface-not-released.rolling.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -1,0 +1,33 @@
+name: Rolling RHEL Binary Build
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 1 * * *'
+
+
+jobs:
+  rolling_rhel_binary:
+    name: Rolling RHEL binary build
+    runs-on: ubuntu-latest
+    env:
+      ROS_DISTRO: rolling
+    container: jaronl/ros:rolling-alma
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: src/kinematics_interface
+      - run: |
+          rosdep update
+          rosdep install -iy --from-path src/kinematics_interface
+          source /opt/ros/${{ env.ROS_DISTRO }}/setup.bash
+          colcon build
+          colcon test

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -23,5 +23,3 @@ jobs:
       ros_repo: main
       upstream_workspace: kinematics_interface.rolling.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -1,0 +1,27 @@
+name: Rolling Semi-Binary Build - main
+# description: 'Build & test that compiles the main dependencies from source.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  semi_binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: main
+      upstream_workspace: kinematics_interface.rolling.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-semi-binary-build-testing.yml
+++ b/.github/workflows/rolling-semi-binary-build-testing.yml
@@ -23,5 +23,3 @@ jobs:
       ros_repo: testing
       upstream_workspace: kinematics_interface.rolling.repos
       ref_for_scheduled_build: master
-    secrets:
-      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-semi-binary-build-testing.yml
+++ b/.github/workflows/rolling-semi-binary-build-testing.yml
@@ -1,0 +1,27 @@
+name: Rolling Semi-Binary Build - testing
+# description: 'Build & test that compiles the main dependencies from source.'
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '33 1 * * *'
+
+jobs:
+  semi_binary:
+    uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
+    with:
+      ros_distro: rolling
+      ros_repo: testing
+      upstream_workspace: kinematics_interface.rolling.repos
+      ref_for_scheduled_build: master
+    secrets:
+      SCH_COMMON_KEY: ${{ secrets.SCH_COMMON_KEY }}

--- a/.github/workflows/rolling-source-build.yml
+++ b/.github/workflows/rolling-source-build.yml
@@ -1,0 +1,19 @@
+name: Rolling Source Build
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '03 3 * * *'
+
+jobs:
+  source:
+    uses: ./.github/workflows/reusable-ros-tooling-source-build.yml
+    with:
+      ros_distro: rolling
+      ref: master
+      ros2_repo_branch: master-rolling

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -36,7 +36,7 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.37.3
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
@@ -49,7 +49,7 @@ repos:
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     - id: flake8
       args: ["--extend-ignore=E501"]
@@ -110,7 +110,7 @@ repos:
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.10.1
+    rev: v1.0.0
     hooks:
       - id: doc8
         args: ['--max-line-length=100', '--ignore=D001']

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # kinematics_interface
 This is a ROS 2 package for using C++ kinematics frameworks in the context of ROS 2 control. A kinematics interface is designed to allow ROS 2 controllers to control robots in Cartesian space. This package also contains a basic implementation of the interface using KDL.
+
+## Build status
+
+ROS2 Distro | Branch | Build status | Documentation | Released packages
+:---------: | :----: | :----------: | :-----------: | :---------------:
+**Rolling** | [`rolling`](https://github.com/ros-controls/kinematics_interface/tree/rolling) | [![Rolling Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-binary-build-main.yml?branch=master) <br /> [![Rolling Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/rolling-semi-binary-build-main.yml?branch=master) |   | [kinematics_interface](https://index.ros.org/p/kinematics_interface/#rolling)
+**Humble** | [`humble`](https://github.com/ros-controls/kinematics_interface/tree/humble) | [![Humble Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-binary-build-main.yml?branch=master) <br /> [![Humble Semi-Binary Build](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-main.yml/badge.svg?branch=master)](https://github.com/ros-controls/kinematics_interface/actions/workflows/humble-semi-binary-build-main.yml?branch=master) |   | [kinematics_interface](https://index.ros.org/p/kinematics_interface/#humble)
+
+### Explanation of different build types
+
+**NOTE**: There are three build stages checking current and future compatibility of the package.
+
+[Detailed build status](.github/workflows/README.md)
+
+1. Binary builds - against released packages (main and testing) in ROS distributions. Shows that direct local build is possible.
+
+   Uses repos file: `$NAME$-not-released.<ros-distro>.repos`
+
+1. Semi-binary builds - against released core ROS packages (main and testing), but the immediate dependencies are pulled from source.
+   Shows that local build with dependencies is possible and if fails there we can expect that after the next package sync we will not be able to build.
+
+   Uses repos file: `$NAME$.repos`

--- a/kinematics_interface-not-released.humble.repos
+++ b/kinematics_interface-not-released.humble.repos
@@ -1,0 +1,6 @@
+repositories:
+  ## EXAMPLE DEPENDENCY
+#   <some_ros_package>:
+#     type: git
+#     url: git@github.com:<some_github_namespace>/<some_ros_package>.git
+#     version: master

--- a/kinematics_interface-not-released.rolling.repos
+++ b/kinematics_interface-not-released.rolling.repos
@@ -1,0 +1,6 @@
+repositories:
+  ## EXAMPLE DEPENDENCY
+#   <some_ros_package>:
+#     type: git
+#     url: git@github.com:<some_github_namespace>/<some_ros_package>.git
+#     version: master

--- a/kinematics_interface.humble.repos
+++ b/kinematics_interface.humble.repos
@@ -1,0 +1,6 @@
+repositories:
+  ## EXAMPLE DEPENDENCY
+#   <some_ros_package>:
+#     type: git
+#     url: git@github.com:<some_github_namespace>/<some_ros_package>.git
+#     version: master

--- a/kinematics_interface.rolling.repos
+++ b/kinematics_interface.rolling.repos
@@ -1,0 +1,6 @@
+repositories:
+  ## EXAMPLE DEPENDENCY
+#   <some_ros_package>:
+#     type: git
+#     url: git@github.com:<some_github_namespace>/<some_ros_package>.git
+#     version: master

--- a/kinematics_interface/include/kinematics_interface/visibility_control.h
+++ b/kinematics_interface/include/kinematics_interface/visibility_control.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IK_PLUGIN_BASE__VISIBILITY_CONTROL_H_
-#define IK_PLUGIN_BASE__VISIBILITY_CONTROL_H_
+#ifndef KINEMATICS_INTERFACE__VISIBILITY_CONTROL_H_
+#define KINEMATICS_INTERFACE__VISIBILITY_CONTROL_H_
 
 // This logic was borrowed (then namespaced) from the examples on the gcc wiki:
 //     https://gcc.gnu.org/wiki/Visibility
@@ -46,4 +46,4 @@
 #define IK_PLUGIN_BASE_PUBLIC_TYPE
 #endif
 
-#endif  // IK_PLUGIN_BASE__VISIBILITY_CONTROL_H_
+#endif  // KINEMATICS_INTERFACE__VISIBILITY_CONTROL_H_

--- a/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
@@ -52,7 +52,7 @@ bool KDLKinematics::initialize(
       end_effector_name.c_str());
     return false;
   }
-  //create map from link names to their index
+  // create map from link names to their index
   for (auto i = 0u; i < chain_.getNrOfSegments(); i++)
   {
     link_name_map_[chain_.getSegment(i).getName()] = i + 1;
@@ -115,7 +115,7 @@ bool KDLKinematics::convert_cartesian_deltas_to_joint_deltas(
   memcpy(delta_x.data(), delta_x_vec.data(), delta_x_vec.size() * sizeof(double));
   // calculate Jacobian
   jac_solver_->JntToJac(q_, *jacobian_, link_name_map_[link_name]);
-  // TODO this dynamic allocation needs to be replaced
+  // TODO(anyone): this dynamic allocation needs to be replaced
   Eigen::Matrix<double, 6, Eigen::Dynamic> J = jacobian_->data;
   // damped inverse
   Eigen::Matrix<double, Eigen::Dynamic, 6> J_inverse =
@@ -180,7 +180,8 @@ bool KDLKinematics::calculate_link_transform(
   // create forward kinematics solver
   fk_pos_solver_->JntToCart(q_, frame_, link_name_map_[link_name]);
   double tmp[] = {frame_.p.x(), frame_.p.y(), frame_.p.z()};
-  // KDL::Rotation stores data in row-major format. e.g Xx, Yx, Zx, Xy... = data index at 0, 1, 2, 3, 4...
+  // KDL::Rotation stores data in row-major format.
+  //      e.g Xx, Yx, Zx, Xy... = data index at 0, 1, 2, 3, 4...
   for (int r = 0; r < 3; r++)
   {
     for (int c = 0; c < 3; c++)

--- a/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/test/test_kinematics_interface_kdl.cpp
@@ -36,7 +36,7 @@ public:
     std::string plugin_name = "kinematics_interface_kdl/KDLKinematics";
     ik_loader_ =
       std::make_shared<pluginlib::ClassLoader<kinematics_interface::KinematicsBaseClass>>(
-        "kinematics_interface_kdl", "kinematics_interface::KinematicsBaseClass");
+        "kinematics_interface", "kinematics_interface::KinematicsBaseClass");
     ik_ = std::unique_ptr<kinematics_interface::KinematicsBaseClass>(
       ik_loader_->createUnmanagedInstance(plugin_name));
   }


### PR DESCRIPTION
Adds default setup for CI as in ros2_control repository.

I have changed how plugins are loaded. They should be exported under `kinematics_interface` group and  not `kinematics_interface_kdl`. Otherwise, there is reduced usefulness of the pluginlib.