### PR TITLE
orocos_kdl_vendor dependency

### DIFF
--- a/kinematics_interface_kdl/CMakeLists.txt
+++ b/kinematics_interface_kdl/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   Eigen3
+  orocos_kdl_vendor
   kdl_parser
   kinematics_interface
   pluginlib

--- a/kinematics_interface_kdl/package.xml
+++ b/kinematics_interface_kdl/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>eigen</depend>
+  <depend>orocos_kdl_vendor</depend>
   <depend>kdl_parser</depend>
   <depend>kinematics_interface</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
Hi! Thought that the `orocos_kdl_vendor` dependency might be missing here. This might be implicitly linked through `kdl_parser`, so I think it doesn't cause issues.