### PR TITLE
Pass the robot_description as an arg in initialize() with fallback to using node's parameters

### DIFF
--- a/kinematics_interface/include/kinematics_interface/kinematics_interface.hpp
+++ b/kinematics_interface/include/kinematics_interface/kinematics_interface.hpp
@@ -42,7 +42,8 @@ public:
    */
   virtual bool initialize(
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-    const std::string & end_effector_name) = 0;
+    const std::string & end_effector_name,
+    const std::string & robot_description = "") = 0;
 
   /**
    * \brief Convert Cartesian delta-x to joint delta-theta, using the Jacobian.

--- a/kinematics_interface_kdl/include/kinematics_interface_kdl/kinematics_interface_kdl.hpp
+++ b/kinematics_interface_kdl/include/kinematics_interface_kdl/kinematics_interface_kdl.hpp
@@ -41,7 +41,8 @@ class KinematicsInterfaceKDL : public kinematics_interface::KinematicsInterface
 public:
   bool initialize(
     std::shared_ptr<rclcpp::node_interfaces::NodeParametersInterface> parameters_interface,
-    const std::string & end_effector_name) override;
+    const std::string & end_effector_name,
+    const std::string & robot_description = "") override;
 
   bool convert_cartesian_deltas_to_joint_deltas(
     const Eigen::VectorXd & joint_pos, const Eigen::Matrix<double, 6, 1> & delta_x,


### PR DESCRIPTION
Per the discussion in the admittance_controller of ros2_controllers (https://github.com/ros-controls/ros2_controllers/pull/1094), pass the robot_description string as an input argument to `initialize()` and fallback to getting the robot_description from the node's parameters.