### PR TITLE
Remove ns from robot_description parameter

### DIFF
--- a/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
@@ -37,7 +37,7 @@ bool KinematicsInterfaceKDL::initialize(
     // If the robot_description input argument is empty, try to get the
     // robot_description from the node's parameters.
     auto robot_param = rclcpp::Parameter();
-    if (!parameters_interface->get_parameter(ns + "robot_description", robot_param))
+    if (!parameters_interface->get_parameter("robot_description", robot_param))
     {
       RCLCPP_ERROR(LOGGER, "parameter robot_description not set in kinematics_interface_kdl");
       return false;


### PR DESCRIPTION
I don't think that the namespace `kinematics` set here
https://github.com/ros-controls/ros2_controllers/blob/f519170c776649de11431addbfe5bba84ac3603d/admittance_controller/include/admittance_controller/admittance_rule_impl.hpp#L62-L63
should apply to the robot_description parameter, which was introduced with #83.

ns should only apply to the latter parameters, which are defined in the admittance_controller
https://github.com/ros-controls/ros2_controllers/blob/master/admittance_controller/src/admittance_controller_parameters.yaml#L34-L55

Removing fixes https://github.com/ros-controls/ros2_controllers/pull/1354 and does not break the rolling version.