### PR TITLE
Add missing dependency on rclcpp

### DIFF
--- a/kinematics_interface/package.xml
+++ b/kinematics_interface/package.xml
@@ -24,6 +24,7 @@
 
   <depend>backward_ros</depend>
   <depend>eigen</depend>
+  <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>


### PR DESCRIPTION
The RHEL 10 builds for Lyrical are a bit more picky about properly declaring dependencies and it appears one is missing here.

Referenced here: https://github.com/ros-controls/kinematics_interface/blob/a407d5849781d52a6db523c5860ce0bb51b25d69/kinematics_interface/CMakeLists.txt#L9

Example failure: https://build.ros2.org/view/Rbin_rhel_el1064/job/Rbin_rhel_el1064__kinematics_interface__rhel_10_x86_64__binary/27/