### PR TITLE
Fix swap in kinematic chain

### DIFF
--- a/kinematics_interface/test/kinematics_interface_common_tests.hpp
+++ b/kinematics_interface/test/kinematics_interface_common_tests.hpp
@@ -280,6 +280,44 @@ TYPED_TEST_P(TestPlugin, plugin_jacobian_and_transform_in_root_frame)
     end_effector_transform.matrix(), MatrixNear(end_effector_transform_est.matrix(), 1e-4));
 }
 
+TYPED_TEST_P(TestPlugin, plugin_swapped_base_tip_keeps_chain_consistent)
+{
+  // Regression test for swapped parameters: if tip is an ancestor of base,
+  // initialization swaps them internally and must also keep the reduced-model
+  // chain consistent with that swap.
+  this->loadBaseParameter("link3");
+  this->loadTipParameter("link1");
+
+  // initialize the plugin
+  ASSERT_TRUE(this->ik_->initialize(this->urdf_, this->node_->get_node_parameters_interface(), ""));
+
+  Eigen::VectorXd pos(2);
+  pos << 0.5, -0.3;
+
+  // After the internal swap, the effective tip should be link3 and the chain should have 2 joints.
+  Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian = Eigen::Matrix<double, 6, 2>::Zero();
+  ASSERT_TRUE(this->ik_->calculate_jacobian(pos, "link3", jacobian));
+
+  Eigen::Matrix<double, 6, 2> jacobian_est;
+  jacobian_est << 0.0, 0.0,  // vx
+    0.431483, 0.0,           // vy
+    -0.789824, 0.0,          // vz
+    1.0, 1.0,                // wx
+    0.0, 0.0,                // wy
+    0.0, 0.0;                // wz
+  EXPECT_THAT(jacobian, MatrixNear(jacobian_est, 1e-4));
+
+  Eigen::Isometry3d end_effector_transform;
+  ASSERT_TRUE(this->ik_->calculate_link_transform(pos, "link3", end_effector_transform));
+
+  Eigen::Isometry3d end_effector_transform_est = Eigen::Isometry3d::Identity();
+  end_effector_transform_est.linear() << 1.0, 0.0, 0.0, 0.0, -0.980067, 0.198669, 0.0, -0.198669,
+    -0.980067;
+  end_effector_transform_est.translation() << 0.0, -0.789824, 0.468517;
+  EXPECT_THAT(
+    end_effector_transform.matrix(), MatrixNear(end_effector_transform_est.matrix(), 1e-4));
+}
+
 TYPED_TEST_P(TestPlugin, plugin_function_std_vector)
 {
   // initialize the plugin
@@ -456,8 +494,9 @@ TYPED_TEST_P(TestPlugin, plugin_no_robot_description)
 REGISTER_TYPED_TEST_SUITE_P(
   TestPlugin, plugin_function_basic, plugin_function_reduced_model_tip,
   plugin_function_reduced_model_base, plugin_jacobian_and_transform_in_root_frame,
-  plugin_function_std_vector, plugin_calculate_frame_difference,
-  plugin_calculate_frame_difference_std_vector, plugin_calculate_frame_difference_rotated_base,
-  incorrect_parameters, incorrect_input_sizes, plugin_no_robot_description);
+  plugin_swapped_base_tip_keeps_chain_consistent, plugin_function_std_vector,
+  plugin_calculate_frame_difference, plugin_calculate_frame_difference_std_vector,
+  plugin_calculate_frame_difference_rotated_base, incorrect_parameters, incorrect_input_sizes,
+  plugin_no_robot_description);
 
 #endif  // KINEMATICS_INTERFACE_COMMON_TESTS_HPP_

--- a/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
+++ b/kinematics_interface_kdl/src/kinematics_interface_kdl.cpp
@@ -84,12 +84,56 @@ bool KinematicsInterfaceKDL::initialize(
     root_name_ = robot_tree.getRootSegment()->first;
   }
 
-  if (!robot_tree.getChain(root_name_, end_effector_name, chain_))
+  KDL::Chain direct_chain;
+  KDL::Chain swapped_chain;
+  const bool has_direct_chain = robot_tree.getChain(root_name_, end_effector_name, direct_chain);
+  const bool has_swapped_chain = robot_tree.getChain(end_effector_name, root_name_, swapped_chain);
+
+  if (!has_direct_chain && !has_swapped_chain)
   {
     RCLCPP_ERROR(
       LOGGER, "failed to find chain from robot root '%s' to end effector '%s'", root_name_.c_str(),
       end_effector_name.c_str());
     return false;
+  }
+
+  bool choose_swapped_chain = !has_direct_chain;
+  if (!choose_swapped_chain && has_swapped_chain)
+  {
+    const auto direct_joints = direct_chain.getNrOfJoints();
+    const auto swapped_joints = swapped_chain.getNrOfJoints();
+
+    if (swapped_joints > direct_joints)
+    {
+      choose_swapped_chain = true;
+    }
+    else if (swapped_joints == direct_joints)
+    {
+      // Tie-breaker: choose orientation where base is closer to tree root than tip.
+      KDL::Chain root_to_base_chain;
+      KDL::Chain root_to_tip_chain;
+      const std::string tree_root = robot_tree.getRootSegment()->first;
+      const bool has_root_to_base = robot_tree.getChain(tree_root, root_name_, root_to_base_chain);
+      const bool has_root_to_tip =
+        robot_tree.getChain(tree_root, end_effector_name, root_to_tip_chain);
+      if (
+        has_root_to_base && has_root_to_tip &&
+        root_to_base_chain.getNrOfSegments() > root_to_tip_chain.getNrOfSegments())
+      {
+        choose_swapped_chain = true;
+      }
+    }
+  }
+
+  if (choose_swapped_chain)
+  {
+    std::swap(root_name_, end_effector_name);
+    chain_ = swapped_chain;
+    RCLCPP_WARN(LOGGER, "Swapping tool and base frame");
+  }
+  else
+  {
+    chain_ = direct_chain;
   }
   // create map from link names to their index
   for (size_t i = 0; i < chain_.getNrOfSegments(); ++i)

--- a/kinematics_interface_pinocchio/src/kinematics_interface_pinocchio.cpp
+++ b/kinematics_interface_pinocchio/src/kinematics_interface_pinocchio.cpp
@@ -201,6 +201,7 @@ bool KinematicsInterfacePinocchio::initialize(
     else
     {
       std::swap(root_name_, end_effector_name);
+      std::swap(base_joint_id, tool_joint_id);
       RCLCPP_WARN(LOGGER, "Swapping tool and base frame");
     }
   }


### PR DESCRIPTION
## Description
This PR adds a focused regression test for kinematics_interface_pinocchio covering the base/tip swap path during initialization.

When users provide base and tip in reverse ancestry order (for example base=link3, tip=link1), the plugin swaps them internally. The new test verifies that this path still produces a consistent reduced chain and correct kinematics outputs.

The regression test also failed for KDL:
KDL can return a valid but zero-DOF chain for reversed inputs, so I’ll make initialization evaluate both directions and choose the chain with the larger joint count (swapping names when needed).

### Is this user-facing behavior change?

yes, but as intented

### Did you use Generative AI?

GPT 5.3