### PR TITLE
Install libboost-devel instead of boost with python support

### DIFF
--- a/.github/workflows/rolling-semi-binary-build-win.yml
+++ b/.github/workflows/rolling-semi-binary-build-win.yml
@@ -24,4 +24,4 @@ jobs:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-win-build.yml@master
     with:
       ros_distro: rolling
-      pixi_dependencies: typeguard jinja2 boost compilers octomap cpp-expected
+      pixi_dependencies: typeguard jinja2 libboost-devel compilers octomap cpp-expected


### PR DESCRIPTION


## Description

Jobs failed with 

```
Error:   × failed to solve requirements of environment 'default' for platform 'win-64'
  ├─▶   × failed to solve the environment

  ╰─▶ Cannot solve the request because of: boost * cannot be installed because there are no viable options:
      ├─ boost 1.85.0 would require
      │  └─ libboost-python-devel ==1.85.0 py312h7e22eef_4, which cannot be installed because there are no viable options:
      │     └─ libboost-python-devel 1.85.0 would require
      │        └─ python >=3.12,<3.13.0a0, for which no candidates were found.

```

### Is this user-facing behavior change?
no
